### PR TITLE
Add client-side background removal web app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
-# johndoehoe
+# Hintergrundentferner
+
+Eine kleine Webanwendung, die mithilfe von TensorFlow.js den Hintergrund von Fotos mit Personen entfernt – direkt im Browser, ohne dass deine Daten den Rechner verlassen.
+
+## Verwendung
+
+1. Öffne die Datei [`index.html`](index.html) in einem aktuellen Browser (empfohlen: Chrome, Edge oder Firefox).
+2. Klicke auf **Bild auswählen** und wähle ein Foto mit einer Person aus.
+3. Nach wenigen Sekunden erscheint eine Version ohne Hintergrund, die du als PNG herunterladen kannst.
+
+> Hinweis: Für bestmögliche Ergebnisse sollte die Person vollständig zu sehen sein und sich klar vom Hintergrund abheben.
+
+## Technik
+
+- [TensorFlow.js](https://www.tensorflow.org/js) & [BodyPix](https://github.com/tensorflow/tfjs-models/tree/master/body-pix) für die Personensegmentierung
+- Moderne Browser-APIs (`FileReader`, `Canvas`) für die clientseitige Bildverarbeitung
+- Keine zusätzlichen Abhängigkeiten oder Build-Schritte erforderlich

--- a/index.html
+++ b/index.html
@@ -1,0 +1,99 @@
+<!DOCTYPE html>
+<html lang="de">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Hintergrund aus Bild entfernen</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header class="hero">
+      <div class="hero__content">
+        <h1>Hintergrundentferner</h1>
+        <p>
+          Lade ein Foto von einer Person hoch und erhalte in wenigen Sekunden eine
+          Version ohne Hintergrund.
+        </p>
+      </div>
+    </header>
+
+    <main>
+      <section class="uploader" aria-label="Bild hochladen">
+        <div class="uploader__input">
+          <input id="fileInput" type="file" accept="image/*" hidden />
+          <label for="fileInput" class="button button--primary">
+            <span>Bild auswählen</span>
+          </label>
+          <p class="uploader__hint">
+            Unterstützt JPG, PNG und WEBP. Die Verarbei­tung findet direkt in
+            deinem Browser statt.
+          </p>
+        </div>
+        <p id="statusText" class="status">
+          Wähle ein Bild, um den Hintergrund zu entfernen.
+        </p>
+        <div id="loadingIndicator" class="loading hidden" role="status">
+          <div class="spinner" aria-hidden="true"></div>
+          <span>Modell wird geladen …</span>
+        </div>
+      </section>
+
+      <section class="previews" aria-live="polite">
+        <article class="card">
+          <h2>Originalbild</h2>
+          <div class="preview-frame">
+            <img
+              id="originalPreview"
+              alt="Vorschau des Originalbildes"
+              class="preview"
+            />
+          </div>
+        </article>
+        <article class="card">
+          <h2>Hintergrund entfernt</h2>
+          <div class="preview-frame preview-frame--transparent">
+            <canvas
+              id="resultCanvas"
+              class="preview"
+              role="img"
+              aria-label="Bild ohne Hintergrund"
+            ></canvas>
+          </div>
+        </article>
+      </section>
+
+      <section class="actions">
+        <a
+          id="downloadButton"
+          class="button button--secondary button--disabled"
+          href="#"
+          download
+          aria-disabled="true"
+        >
+          PNG herunterladen
+        </a>
+        <button id="resetButton" type="button" class="button button--ghost">
+          Neues Bild wählen
+        </button>
+      </section>
+    </main>
+
+    <footer class="footer">
+      <p>
+        Diese Demo nutzt das BodyPix-Modell von TensorFlow.js, um Personen im
+        Bild zu erkennen und den Hintergrund zu entfernen. Alle Berechnungen
+        werden lokal ausgeführt.
+      </p>
+    </footer>
+
+    <script src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs@4.10.0/dist/tf.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@tensorflow-models/body-pix@2.2.0/dist/body-pix.min.js"></script>
+    <script src="script.js" defer></script>
+  </body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,208 @@
+const fileInput = document.getElementById('fileInput');
+const statusText = document.getElementById('statusText');
+const loadingIndicator = document.getElementById('loadingIndicator');
+const originalPreview = document.getElementById('originalPreview');
+const resultCanvas = document.getElementById('resultCanvas');
+const downloadButton = document.getElementById('downloadButton');
+const resetButton = document.getElementById('resetButton');
+
+let netPromise = null;
+let activeTaskId = 0;
+
+const defaultStatus = 'Wähle ein Bild, um den Hintergrund zu entfernen.';
+
+function setStatus(message, isError = false) {
+  statusText.textContent = message;
+  statusText.classList.toggle('error', isError);
+}
+
+function toggleLoading(show, message) {
+  if (show) {
+    if (message) {
+      const textNode = loadingIndicator.querySelector('span');
+      if (textNode) {
+        textNode.textContent = message;
+      }
+    }
+    loadingIndicator.classList.remove('hidden');
+  } else {
+    loadingIndicator.classList.add('hidden');
+  }
+}
+
+function clearResults() {
+  const ctx = resultCanvas.getContext('2d');
+  ctx.clearRect(0, 0, resultCanvas.width, resultCanvas.height);
+  resultCanvas.width = resultCanvas.height = 0;
+  downloadButton.classList.add('button--disabled');
+  downloadButton.setAttribute('aria-disabled', 'true');
+  downloadButton.removeAttribute('href');
+  downloadButton.removeAttribute('download');
+}
+
+function resetInterface(clearFileInput = true, cancelProcessing = false) {
+  if (clearFileInput) {
+    fileInput.value = '';
+  }
+  if (cancelProcessing) {
+    activeTaskId += 1;
+  }
+  originalPreview.removeAttribute('src');
+  originalPreview.classList.remove('visible');
+  clearResults();
+  setStatus(defaultStatus);
+  toggleLoading(false);
+}
+
+async function ensureModelLoaded() {
+  if (!netPromise) {
+    toggleLoading(true, 'Modell wird geladen …');
+    netPromise = bodyPix.load({
+      architecture: 'MobileNetV1',
+      outputStride: 16,
+      multiplier: 0.75,
+      quantBytes: 2,
+    });
+  }
+  return netPromise;
+}
+
+async function handleFileChange(event) {
+  const file = event.target.files && event.target.files[0];
+  if (!file) {
+    return;
+  }
+
+  resetInterface(false);
+  const taskId = ++activeTaskId;
+  const fileName = file.name.replace(/\.[^.]+$/, '') || 'bild';
+
+  setStatus('Bild wird geladen …');
+
+  const reader = new FileReader();
+  reader.onload = () => {
+    const image = new Image();
+    image.onload = () => {
+      originalPreview.src = reader.result;
+      originalPreview.classList.add('visible');
+      processImage(image, { fileName, taskId })
+        .then(() => {
+          if (taskId === activeTaskId) {
+            fileInput.value = '';
+          }
+        })
+        .catch((error) => {
+          console.error(error);
+          if (taskId === activeTaskId) {
+            if (error.message === 'Keine Person erkannt') {
+              setStatus(
+                'Es konnte keine Person im Bild erkannt werden. Bitte wähle ein anderes Foto.',
+                true,
+              );
+            } else {
+              setStatus(
+                'Ups, etwas ist schiefgelaufen. Bitte versuche es mit einem anderen Bild erneut.',
+                true,
+              );
+            }
+            clearResults();
+          }
+        });
+    };
+    image.onerror = () => {
+      setStatus('Das Bild konnte nicht geladen werden.', true);
+    };
+    image.src = reader.result;
+  };
+  reader.onerror = () => {
+    setStatus('Die Bilddatei konnte nicht gelesen werden.', true);
+  };
+  reader.readAsDataURL(file);
+}
+
+async function processImage(imageElement, { fileName, taskId }) {
+  if (taskId !== activeTaskId) {
+    return;
+  }
+
+  toggleLoading(true, 'Hintergrund wird entfernt …');
+  setStatus('Hintergrund wird entfernt …');
+
+  try {
+    const net = await ensureModelLoaded();
+    if (taskId !== activeTaskId) {
+      return;
+    }
+
+    toggleLoading(true, 'Hintergrund wird entfernt …');
+
+    const segmentation = await net.segmentPerson(imageElement, {
+      internalResolution: 'medium',
+      segmentationThreshold: 0.7,
+    });
+
+    if (taskId !== activeTaskId) {
+      return;
+    }
+
+    const { width, height, data: maskData } = segmentation;
+    const totalPixels = maskData.length;
+
+    const offscreenCanvas = document.createElement('canvas');
+    offscreenCanvas.width = width;
+    offscreenCanvas.height = height;
+    const offscreenCtx = offscreenCanvas.getContext('2d');
+    offscreenCtx.drawImage(imageElement, 0, 0, width, height);
+    const sourceImageData = offscreenCtx.getImageData(0, 0, width, height);
+    const sourcePixels = sourceImageData.data;
+
+    const outputPixels = new Uint8ClampedArray(sourcePixels.length);
+    let personPixelCount = 0;
+
+    for (let i = 0; i < totalPixels; i += 1) {
+      const offset = i * 4;
+      if (maskData[i] === 1) {
+        outputPixels[offset] = sourcePixels[offset];
+        outputPixels[offset + 1] = sourcePixels[offset + 1];
+        outputPixels[offset + 2] = sourcePixels[offset + 2];
+        outputPixels[offset + 3] = 255;
+        personPixelCount += 1;
+      } else {
+        outputPixels[offset] = 0;
+        outputPixels[offset + 1] = 0;
+        outputPixels[offset + 2] = 0;
+        outputPixels[offset + 3] = 0;
+      }
+    }
+
+    if (personPixelCount === 0) {
+      throw new Error('Keine Person erkannt');
+    }
+
+    if (taskId !== activeTaskId) {
+      return;
+    }
+
+    resultCanvas.width = width;
+    resultCanvas.height = height;
+    const ctx = resultCanvas.getContext('2d');
+    ctx.putImageData(new ImageData(outputPixels, width, height), 0, 0);
+
+    const dataUrl = resultCanvas.toDataURL('image/png');
+    downloadButton.href = dataUrl;
+    downloadButton.download = `${fileName}-ohne-hintergrund.png`;
+    downloadButton.classList.remove('button--disabled');
+    downloadButton.removeAttribute('aria-disabled');
+
+    setStatus('Fertig! Lade dein Bild ohne Hintergrund herunter.');
+  } finally {
+    if (taskId === activeTaskId) {
+      toggleLoading(false);
+    }
+  }
+}
+
+fileInput.addEventListener('change', handleFileChange);
+resetButton.addEventListener('click', () => resetInterface(true, true));
+
+resetInterface();

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,282 @@
+:root {
+  color-scheme: light;
+  --bg-gradient: linear-gradient(135deg, #0f172a 0%, #312e81 100%);
+  --text-primary: #0f172a;
+  --text-secondary: #334155;
+  --surface: rgba(255, 255, 255, 0.92);
+  --surface-strong: #ffffff;
+  --accent: #6366f1;
+  --accent-dark: #4f46e5;
+  --accent-soft: rgba(99, 102, 241, 0.12);
+  --border: rgba(15, 23, 42, 0.08);
+  --shadow: 0 25px 50px -12px rgba(15, 23, 42, 0.35);
+  --radius-lg: 24px;
+  --radius-md: 16px;
+  --radius-sm: 12px;
+  --transition: 0.25s ease;
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI',
+    sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  background: var(--bg-gradient);
+  color: var(--text-primary);
+}
+
+.hero {
+  width: min(960px, calc(100% - 3rem));
+  padding: 3rem 2rem 1rem;
+  color: white;
+  text-align: center;
+}
+
+.hero__content {
+  max-width: 560px;
+  margin: 0 auto;
+}
+
+.hero h1 {
+  margin: 0 0 0.75rem;
+  font-size: clamp(2.25rem, 4vw, 3.25rem);
+  font-weight: 700;
+}
+
+.hero p {
+  margin: 0;
+  font-size: 1.125rem;
+  line-height: 1.6;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+main {
+  width: min(960px, calc(100% - 3rem));
+  background: var(--surface);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow);
+  padding: clamp(1.5rem, 4vw, 3rem);
+  backdrop-filter: blur(12px);
+}
+
+.uploader {
+  background: var(--surface-strong);
+  border-radius: var(--radius-md);
+  padding: 2rem;
+  border: 1px solid var(--border);
+  text-align: center;
+  display: grid;
+  gap: 1.5rem;
+}
+
+.uploader__hint {
+  margin: 0.5rem 0 0;
+  color: var(--text-secondary);
+  font-size: 0.95rem;
+}
+
+.status {
+  margin: 0;
+  font-weight: 600;
+  color: var(--accent-dark);
+}
+
+.status.error {
+  color: #b91c1c;
+}
+
+.loading {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  color: var(--text-secondary);
+  font-size: 0.95rem;
+}
+
+.loading.hidden {
+  display: none;
+}
+
+.spinner {
+  width: 1.5rem;
+  height: 1.5rem;
+  border-radius: 50%;
+  border: 3px solid rgba(99, 102, 241, 0.2);
+  border-top-color: var(--accent);
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.previews {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.5rem;
+  margin-top: 2rem;
+}
+
+.card {
+  background: var(--surface-strong);
+  border-radius: var(--radius-md);
+  padding: 1.5rem;
+  border: 1px solid var(--border);
+  box-shadow: 0 10px 30px -18px rgba(15, 23, 42, 0.6);
+}
+
+.card h2 {
+  margin: 0 0 1rem;
+  font-size: 1.15rem;
+}
+
+.preview-frame {
+  position: relative;
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+  border: 1px solid rgba(15, 23, 42, 0.06);
+  background: #f1f5f9;
+  min-height: 240px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.preview-frame--transparent {
+  background-image: linear-gradient(45deg, #e2e8f0 25%, transparent 25%),
+    linear-gradient(-45deg, #e2e8f0 25%, transparent 25%),
+    linear-gradient(45deg, transparent 75%, #e2e8f0 75%),
+    linear-gradient(-45deg, transparent 75%, #e2e8f0 75%);
+  background-size: 24px 24px;
+  background-position: 0 0, 0 12px, 12px -12px, -12px 0;
+}
+
+.preview {
+  max-width: 100%;
+  width: 100%;
+}
+
+img.preview {
+  display: none;
+  height: auto;
+}
+
+img.preview.visible {
+  display: block;
+}
+
+canvas.preview {
+  display: block;
+  width: 100%;
+  height: auto;
+  image-rendering: optimizeQuality;
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  justify-content: center;
+  margin-top: 2.5rem;
+}
+
+.button {
+  border: none;
+  border-radius: 999px;
+  padding: 0.85rem 1.8rem;
+  font-weight: 600;
+  font-size: 1rem;
+  cursor: pointer;
+  text-decoration: none;
+  transition: transform var(--transition), box-shadow var(--transition);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+}
+
+.button--primary {
+  background: var(--accent);
+  color: white;
+  box-shadow: 0 12px 30px -12px rgba(99, 102, 241, 0.7);
+}
+
+.button--primary:hover,
+.button--primary:focus-visible {
+  background: var(--accent-dark);
+  transform: translateY(-2px);
+}
+
+.button--secondary {
+  background: white;
+  color: var(--accent-dark);
+  border: 1px solid rgba(99, 102, 241, 0.4);
+}
+
+.button--secondary:hover,
+.button--secondary:focus-visible {
+  box-shadow: 0 12px 30px -18px rgba(99, 102, 241, 0.6);
+  transform: translateY(-2px);
+}
+
+.button--ghost {
+  background: transparent;
+  color: var(--text-secondary);
+  border: 1px solid var(--border);
+}
+
+.button--ghost:hover,
+.button--ghost:focus-visible {
+  color: var(--accent-dark);
+  border-color: rgba(99, 102, 241, 0.5);
+}
+
+.button--disabled,
+.button[aria-disabled='true'] {
+  pointer-events: none;
+  opacity: 0.55;
+  box-shadow: none;
+}
+
+.footer {
+  width: min(960px, calc(100% - 3rem));
+  padding: 2rem 0 3rem;
+  text-align: center;
+  color: rgba(255, 255, 255, 0.78);
+  font-size: 0.95rem;
+  line-height: 1.6;
+}
+
+@media (max-width: 720px) {
+  main {
+    padding: 1.75rem;
+  }
+
+  .uploader {
+    padding: 1.5rem;
+  }
+}
+
+@media (max-width: 540px) {
+  .hero {
+    padding-top: 2.25rem;
+  }
+
+  main {
+    width: min(100%, calc(100% - 1.5rem));
+  }
+
+  .preview-frame {
+    min-height: 200px;
+  }
+}


### PR DESCRIPTION
## Summary
- create a single-page interface for uploading images and previewing the background removal results
- implement client-side background removal with TensorFlow.js BodyPix and download/reset controls
- add polished styling and documentation for running the tool

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d167991f2c8327b77205d493e58094