### PR TITLE
Improve BodyPix segmentation quality

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Eine kleine Webanwendung, die mithilfe von TensorFlow.js den Hintergrund von Fot
 2. Klicke auf **Bild auswählen** und wähle ein Foto mit einer Person aus.
 3. Nach wenigen Sekunden erscheint eine Version ohne Hintergrund, die du als PNG herunterladen kannst.
 
-> Hinweis: Beim ersten Start lädt die Anwendung ein hochauflösendes BodyPix-Modell (ResNet50). Je nach Gerät kann dies einige Sekunden dauern.
+> Hinweis: Beim ersten Start lädt die Anwendung ein hochauflösendes BodyPix-Modell (ResNet50 mit vierfach quantisierten Gewichten). Je nach Gerät kann dies einige Sekunden dauern.
 
 > Hinweis: Für bestmögliche Ergebnisse sollte die Person vollständig zu sehen sein und sich klar vom Hintergrund abheben.
 
@@ -16,4 +16,5 @@ Eine kleine Webanwendung, die mithilfe von TensorFlow.js den Hintergrund von Fot
 
 - [TensorFlow.js](https://www.tensorflow.org/js) & [BodyPix](https://github.com/tensorflow/tfjs-models/tree/master/body-pix) für die Personensegmentierung
 - Moderne Browser-APIs (`FileReader`, `Canvas`) für die clientseitige Bildverarbeitung
+- Zusätzliche Masken-Nachbearbeitung (Dilatation + weiches Ausblenden), damit feine Details wie Haare erhalten bleiben
 - Keine zusätzlichen Abhängigkeiten oder Build-Schritte erforderlich

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Eine kleine Webanwendung, die mithilfe von TensorFlow.js den Hintergrund von Fot
 2. Klicke auf **Bild auswählen** und wähle ein Foto mit einer Person aus.
 3. Nach wenigen Sekunden erscheint eine Version ohne Hintergrund, die du als PNG herunterladen kannst.
 
+> Hinweis: Beim ersten Start lädt die Anwendung ein hochauflösendes BodyPix-Modell (ResNet50). Je nach Gerät kann dies einige Sekunden dauern.
+
 > Hinweis: Für bestmögliche Ergebnisse sollte die Person vollständig zu sehen sein und sich klar vom Hintergrund abheben.
 
 ## Technik


### PR DESCRIPTION
## Summary
- load BodyPix with the high-precision ResNet50 backbone and tightened segmentation settings for cleaner cut-outs
- blend the person into the output canvas via a blurred BodyPix mask instead of binary alpha values
- mention the longer initial model load in the README status copy

## Testing
- Playwright smoke test (fails: WebGL is not supported in the headless test environment)


------
https://chatgpt.com/codex/tasks/task_e_68d16edfa64c832788540816af4a1dca